### PR TITLE
various: add integration tests

### DIFF
--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -1,0 +1,149 @@
+package integration
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/andrew-d/homeauth/internal/testproc"
+)
+
+var configTemplate = template.Must(template.New("config").Parse(strings.TrimSpace(`
+http://auth.example.com {
+	bind unix/{{ .AuthSocket }}
+	reverse_proxy {{ .AuthAddr }}
+}
+
+http://protected.example.com {
+	bind unix/{{ .ProtectedSocket }}
+
+	forward_auth {{ .AuthAddr }} {
+		uri /api/verify?behaviour=redirect
+		copy_headers Remote-User Remote-Groups Remote-Name Remote-Email
+	}
+
+	file_server browse {
+		root {{ .ProtectedDir }}
+	}
+}
+`)))
+
+func TestCaddy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	caddyBin, err := exec.LookPath("caddy")
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			t.Skip("caddy not found in PATH")
+		}
+
+		t.Fatalf("caddy not found in PATH: %v", err)
+	}
+
+	bin := buildHomeauth(t)
+	ctx, addr := startHomeauth(t, bin, startOptions{
+		Domain:    "example.com",
+		ServerURL: "http://auth.example.com",
+	})
+
+	// Create a Caddy config file
+	confFile, err := os.Create(filepath.Join(t.TempDir(), "Caddyfile"))
+	if err != nil {
+		t.Fatalf("failed to create Caddy config file: %v", err)
+	}
+	defer confFile.Close()
+
+	pdir := filepath.Join(t.TempDir(), "protected")
+	if err := os.Mkdir(pdir, 0755); err != nil {
+		t.Fatalf("failed to create protected directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pdir, "index.html"), []byte("Super secret"), 0644); err != nil {
+		t.Fatalf("failed to write index.html: %v", err)
+	}
+
+	authSocket := filepath.Join(t.TempDir(), "auth.sock")
+	protectedSocket := filepath.Join(t.TempDir(), "protected.sock")
+
+	if err := configTemplate.Execute(confFile, map[string]any{
+		"AuthAddr":        addr,
+		"ProtectedDir":    pdir,
+		"AuthSocket":      authSocket,
+		"ProtectedSocket": protectedSocket,
+	}); err != nil {
+		t.Fatalf("failed to execute Caddy config template: %v", err)
+	}
+
+	// Start Caddy
+	proc := testproc.New(t, caddyBin, []string{"run", "--config", confFile.Name()}, &testproc.Options{
+		ShutdownSignal: syscall.SIGTERM,
+		LogStdout:      true,
+		LogStderr:      true,
+	})
+
+	// Wait for it to create the Unix sockets.
+	proc.WaitForFiles(time.Second, authSocket, protectedSocket)
+
+	// Create a second context that is canceled when either our original
+	// context is, or the Caddy process exits.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-proc.Context().Done():
+			cancel()
+		}
+	}()
+
+	tt := newTester(t, ctx, "http://auth.example.com")
+
+	// Configure the http.Client to dial our Unix socket(s)
+	tt.client.Transport = &http.Transport{
+		DialContext: (unixSocketDialer{
+			"auth.example.com":      authSocket,
+			"protected.example.com": protectedSocket,
+		}).DialContext,
+	}
+
+	// Verify that a request to our protected resource does not work before
+	// we log in; we expect a redirect to our auth service.
+	req := must(http.NewRequestWithContext(proc.Context(), "GET", "http://protected.example.com/index.html", nil))
+	resp := must(tt.client.Do(req))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got status %d, want 200", resp.StatusCode)
+	}
+	if hostname := resp.Request.URL.Hostname(); hostname != "auth.example.com" {
+		t.Fatalf("expected redirect to auth service, but got: %v", resp.Request.URL)
+	}
+	body := must(io.ReadAll(resp.Body))
+	if bytes.Contains(body, []byte("Super secret")) {
+		t.Fatalf("did not expect to find \"Super secret\" in response")
+	}
+
+	// Then log in to homeauth.
+	tt.loginPassword("andrew@du.nham.ca", "password")
+
+	// We should be able to make a request to our protected site now, and
+	// the verification should work fine.
+	req = must(http.NewRequestWithContext(proc.Context(), "GET", "http://protected.example.com/index.html", nil))
+	resp = must(tt.client.Do(req))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got status %d, want 200", resp.StatusCode)
+	}
+	body = must(io.ReadAll(resp.Body))
+	if string(body) != "Super secret" {
+		t.Fatalf("got body %q, want %q", body, "Super secret")
+	}
+}

--- a/integration/helpers_test.go
+++ b/integration/helpers_test.go
@@ -1,0 +1,278 @@
+package integration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/andrew-d/homeauth/internal/repodir"
+	"github.com/andrew-d/homeauth/internal/testproc"
+	"golang.org/x/net/html"
+	"golang.org/x/net/publicsuffix"
+)
+
+func buildHomeauth(tb testing.TB) string {
+	tb.Helper()
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		tb.Skip("go binary not found in PATH")
+	}
+	rootDir, err := repodir.Root()
+	if err != nil {
+		tb.Fatalf("finding root directory: %v", err)
+	}
+
+	out := filepath.Join(tb.TempDir(), "homeauth")
+	cmd := exec.Command(goBin, "build", "-o", out, "./cmd/homeauth")
+	cmd.Dir = rootDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		tb.Fatalf("building homeauth: %v", err)
+	}
+	return out
+}
+
+const testConfigFile = `{
+  "Config": {
+    "CookieDomain": %q
+  },
+  "Users": {
+    "a666702e-fc59-4175-9885-01282eaf49da": {
+      "UUID": "a666702e-fc59-4175-9885-01282eaf49da",
+      "Email": "andrew@du.nham.ca",
+      "PasswordHash": "$argon2id$v=19$m=65536,t=1,p=4$dGVzdDEyMzQ$XdbBVl1PgOPDzbRIwKKoVw"
+    }
+  }
+}`
+
+type startOptions struct {
+	Domain    string // Cookie domain, required
+	ServerURL string // --server-url flag, optional
+}
+
+func startHomeauth(tb testing.TB, bin string, opts startOptions) (context.Context, string) {
+	tb.Helper()
+
+	if opts.Domain == "" {
+		tb.Fatal("Domain option is required")
+	}
+
+	// Write out database file.
+	tdir := tb.TempDir()
+	dbPath := filepath.Join(tdir, "data.json")
+	if err := os.WriteFile(
+		dbPath,
+		[]byte(fmt.Sprintf(testConfigFile, opts.Domain)),
+		0o644,
+	); err != nil {
+		tb.Fatalf("writing config file: %v", err)
+	}
+
+	// Create listener in parent process and pass to child.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		tb.Fatalf("error listening: %v", err)
+	}
+	tb.Cleanup(func() { ln.Close() })
+	lnFile, err := ln.(*net.TCPListener).File()
+	if err != nil {
+		tb.Fatalf("error getting FD for listener: %v", err)
+	}
+
+	addr := ln.Addr().(*net.TCPAddr)
+	tb.Logf("server listening on: %v", addr)
+
+	args := []string{
+		"--verbose",
+		"--listen", "fd://3",
+		"--db", dbPath,
+	}
+	if opts.ServerURL != "" {
+		args = append(args, "--server-url", opts.ServerURL)
+	}
+
+	proc := testproc.New(tb, bin, args, &testproc.Options{
+		ExtraFiles: []*os.File{lnFile},
+
+		ShutdownSignal: syscall.SIGTERM,
+		LogStdout:      true,
+		LogStderr:      true,
+	})
+
+	// Wait until the server is running.
+	serverAddr := fmt.Sprintf("http://localhost:%d", addr.Port)
+	livezURL := serverAddr + "/livez"
+	proc.WaitForHttpOK(100*time.Millisecond, http.DefaultClient, livezURL)
+
+	// If the Wait failed, it will log an error but continue; we want to
+	// abort the test, so call FailNow to do that.
+	if tb.Failed() {
+		tb.FailNow()
+	}
+	return proc.Context(), serverAddr
+}
+
+type tester struct {
+	tb     testing.TB
+	ctx    context.Context
+	client *http.Client
+	addr   string
+}
+
+func newTester(tb testing.TB, ctx context.Context, addr string) *tester {
+	jar, err := cookiejar.New(&cookiejar.Options{
+		PublicSuffixList: publicsuffix.List,
+	})
+	if err != nil {
+		tb.Fatalf("failed to create cookie jar: %v", err)
+	}
+
+	ret := &tester{
+		tb:  tb,
+		ctx: ctx,
+		client: &http.Client{
+			Jar: jar,
+		},
+		addr: addr,
+	}
+	tb.Cleanup(ret.client.CloseIdleConnections)
+	return ret
+}
+
+func (t *tester) MustGet(path string) *http.Response {
+	req, err := http.NewRequestWithContext(t.ctx, "GET", t.addr+path, nil)
+	if err != nil {
+		t.tb.Fatalf("creating GET request %q: %v", path, err)
+	}
+	resp, err := t.client.Do(req)
+	if err != nil {
+		t.tb.Fatalf("making GET request %q: %v", path, err)
+	}
+	return resp
+}
+
+func (t *tester) loginPassword(user, password string) {
+	// Get the /login page to extract the CSRF token
+	resp := t.MustGet("/login")
+	if resp.StatusCode != http.StatusOK {
+		t.tb.Fatalf("got status %d, want 200", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+
+	csrfToken := extractCSRFToken(t.tb, body)
+	if csrfToken == "" {
+		t.tb.Fatalf("failed to extract CSRF token")
+	}
+
+	postVals := url.Values{
+		"username":           {user},
+		"password":           {password},
+		"via":                {"password"},
+		"gorilla.csrf.Token": {csrfToken},
+	}
+	resp, err := t.client.PostForm(t.addr+"/login", postVals)
+	if err != nil {
+		t.tb.Fatalf("making POST request to /login: %v", err)
+	}
+	resp.Body.Close()
+
+	// Ensure that the user is authenticated by fetching the /account page
+	resp = t.MustGet("/account")
+	if resp.StatusCode != http.StatusOK {
+		t.tb.Fatalf("got status %d, want 200", resp.StatusCode)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	if !bytes.Contains(body, []byte("Account Information")) {
+		t.tb.Fatalf("expected 'Account Information' in body")
+	}
+}
+
+// extractCSRFToken extracts the CSRF token from an HTML document.
+func extractCSRFToken(tb testing.TB, body []byte) string {
+	tb.Helper()
+	doc, err := html.Parse(bytes.NewReader(body))
+	if err != nil {
+		tb.Fatalf("failed to parse HTML: %v", err)
+	}
+
+	const tokenName = "gorilla.csrf.Token"
+
+	// Define a helper function to recursively traverse the HTML nodes.
+	var findToken func(*html.Node) string
+	findToken = func(n *html.Node) string {
+		if n.Type == html.ElementNode && n.Data == "input" {
+			var name, value string
+			for _, attr := range n.Attr {
+				if attr.Key == "name" && attr.Val == tokenName {
+					name = attr.Val
+				}
+				if attr.Key == "value" {
+					value = attr.Val
+				}
+			}
+			if name == tokenName {
+				return value
+			}
+		}
+
+		// Recursively traverse child nodes.
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			if token := findToken(c); token != "" {
+				return token
+			}
+		}
+
+		return ""
+	}
+
+	// Start the search from the root node.
+	if tok := findToken(doc); tok != "" {
+		return tok
+	}
+
+	tb.Fatalf("failed to find CSRF token in HTML")
+	return ""
+}
+
+func must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// unixSocketDialer is a dialer that can dial unix sockets, and exposes a
+// DialContext method.
+//
+// The map is from the host to dial to the path to the socket; e.g.:
+//
+//	unixSocketDialer{
+//		"example.com": "/tmp/example.sock",
+//	}
+type unixSocketDialer map[string]string
+
+func (u unixSocketDialer) DialContext(_ context.Context, _, addr string) (net.Conn, error) {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("splitting host/port: %w", err)
+	}
+
+	sockPath, ok := u[host]
+	if !ok {
+		return nil, fmt.Errorf("unknown host %q", host)
+	}
+	return net.Dial("unix", sockPath)
+}

--- a/integration/homeauth.json
+++ b/integration/homeauth.json
@@ -1,0 +1,1 @@
+{"AccessTokens":null,"MagicLinks":null,"OAuthCodes":null,"PendingEmails":null,"Users":null,"WebAuthnCreds":null,"Sessions":null,"Config":{"Clients":null,"PrimarySigningKeyID":"","SigningKeys":null,"SecureCookieKey":"6RM1nUftVLxWGApMl7/K+G2P4dQfjTN4LIZH4n6Wc0M=","CookieDomain":"","CSRFKey":"WXOJ8cFOFOW1f1LJiRnCYXQJkt87uKRvxo50l+dL/yc=","Email":null}}

--- a/integration/smoke_test.go
+++ b/integration/smoke_test.go
@@ -1,0 +1,17 @@
+package integration
+
+import "testing"
+
+// TestSmoke verifies that the server boots and responds to HTTP requests.
+func TestSmoke(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
+	bin := buildHomeauth(t)
+	ctx, addr := startHomeauth(t, bin, startOptions{Domain: "localhost"})
+
+	// Log in
+	tt := newTester(t, ctx, addr)
+	tt.loginPassword("andrew@du.nham.ca", "password")
+}

--- a/internal/testproc/logger.go
+++ b/internal/testproc/logger.go
@@ -1,0 +1,65 @@
+package testproc
+
+import (
+	"bytes"
+)
+
+type lineWriter struct {
+	buffer    bytes.Buffer
+	writeFunc func(string) error
+}
+
+// newLineWriter creates a new lineWriter that will call the given function
+// with each complete line.
+func newLineWriter(fn func(string) error) *lineWriter {
+	return &lineWriter{
+		writeFunc: fn,
+	}
+}
+
+// Write implements the io.Writer interface. It writes data to the buffer and
+// calls the provided function for each complete line.
+func (lw *lineWriter) Write(p []byte) (n int, err error) {
+	n = len(p)
+	start := 0
+
+	for i, b := range p {
+		if b == '\n' {
+			// Write up to and including the newline to the buffer.
+			lw.buffer.Write(p[start : i+1])
+
+			// Flush the buffer, including this newline-ended line.
+			if err := lw.flush(true); err != nil {
+				return n, err
+			}
+
+			// Move the start index to the next byte after the newline.
+			start = i + 1
+		}
+	}
+
+	// Write any remaining bytes to the buffer that don't include a newline.
+	if start < len(p) {
+		lw.buffer.Write(p[start:])
+	}
+
+	return n, nil
+}
+
+// flush flushes the buffer. If `hasNewline` is true, removes the newline.
+func (lw *lineWriter) flush(hasNewline bool) error {
+	line := lw.buffer.String()
+	lw.buffer.Reset()
+	if hasNewline && len(line) > 0 {
+		line = line[:len(line)-1] // Remove newline character
+	}
+	return lw.writeFunc(line)
+}
+
+// Close flushes any remaining buffered data that hasn't been flushed yet.
+func (lw *lineWriter) Close() error {
+	if lw.buffer.Len() > 0 {
+		return lw.flush(false)
+	}
+	return nil
+}

--- a/internal/testproc/logger_test.go
+++ b/internal/testproc/logger_test.go
@@ -1,0 +1,80 @@
+package testproc
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestLineWriter(t *testing.T) {
+	tests := []struct {
+		name   string
+		writes []string
+		want   []string
+	}{
+		{
+			name:   "single_line_with_newline",
+			writes: []string{"hello, world\n"},
+			want:   []string{"hello, world"},
+		},
+		{
+			name:   "single_line_without_newline",
+			writes: []string{"hello, world"},
+			want:   []string{"hello, world"},
+		},
+		{
+			name:   "multiple_lines",
+			writes: []string{"line1\nline2\nline3\n"},
+			want:   []string{"line1", "line2", "line3"},
+		},
+		{
+			name:   "partial_then_full",
+			writes: []string{"line1 ", "line2\nline3"},
+			want:   []string{"line1 line2", "line3"},
+		},
+		{
+			name:   "blank lines",
+			writes: []string{"\n", "foo\n"},
+			want:   []string{"", "foo"},
+		},
+		{
+			name:   "empty",
+			writes: []string{""},
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockFunc{}
+			lw := newLineWriter(mock.Handle)
+
+			for i, write := range tt.writes {
+				n, err := lw.Write([]byte(write))
+				if err != nil {
+					t.Fatalf("Write(%q) [i=%d] got unexpected error: %v", write, i, err)
+				}
+				if n > len(write) {
+					t.Fatalf("Write(%q) [i=%d] wrote more than the input: %d > %d", write, i, n, len(write))
+				}
+			}
+
+			// Close to flush any remaining data.
+			if err := lw.Close(); err != nil {
+				t.Fatalf("Close got unexpected error: %v", err)
+			}
+
+			if !slices.Equal(mock.got, tt.want) {
+				t.Errorf("got lines %+v, want %+v", mock.got, tt.want)
+			}
+		})
+	}
+}
+
+type mockFunc struct {
+	got []string
+}
+
+func (m *mockFunc) Handle(line string) error {
+	m.got = append(m.got, line)
+	return nil
+}

--- a/internal/testproc/testproc.go
+++ b/internal/testproc/testproc.go
@@ -1,0 +1,221 @@
+// Package testproc contains a helper for launching a subprocess in a test,
+// monitoring it during the lifetime of the test, and ensuring it's terminated
+// gracefully when then test is done.
+package testproc
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type Options struct {
+	// ShutdownSignal, if non-zero, will be sent to the process when the
+	// test finishes to allow it to gracefully shut down. If not specified,
+	// the process will be killed.
+	ShutdownSignal syscall.Signal
+
+	// ShutdownTimeout is the timeout between when ShutdownSignal is sent
+	// (if any) and when the process is killed.
+	//
+	// If zero, a default value of 2 seconds is used.
+	ShutdownTimeout time.Duration
+
+	// LogStdout and LogStderr, if set, will capture and log stdout or
+	// stderr (respectively) from the subprocess to the test's logger,
+	// prefixed with the name of the binary.
+	//
+	// They override the Stdout/Stderr options, below.
+	LogStdout bool
+	LogStderr bool
+
+	// The following fields are copied to the *exec.Cmd's fields of the
+	// same name without modification.
+	Stdin      io.Reader
+	Stdout     io.Writer
+	Stderr     io.Writer
+	Env        []string
+	Dir        string
+	ExtraFiles []*os.File
+}
+
+type Proc struct {
+	tb  testing.TB
+	ctx context.Context
+	cmd *exec.Cmd
+}
+
+func New(tb testing.TB, name string, args []string, opts *Options) *Proc {
+	// ctx tracks the lifetime of the process, and is canceled when the
+	// process exits.
+	ctx, cancel := context.WithCancel(context.Background())
+	procBase := filepath.Base(name)
+	cmd := exec.Command(name, args...)
+	if opts != nil {
+		cmd.Stdin = opts.Stdin
+		cmd.Dir = opts.Dir
+		cmd.Env = opts.Env
+		cmd.ExtraFiles = opts.ExtraFiles
+
+		if opts.LogStdout {
+			cmd.Stdout = newLineWriter(func(line string) error {
+				tb.Logf("%s: stdout: %s", procBase, line)
+				return nil
+			})
+		} else {
+			cmd.Stdout = opts.Stdout
+		}
+
+		if opts.LogStderr {
+			cmd.Stderr = newLineWriter(func(line string) error {
+				tb.Logf("%s: stderr: %s", procBase, line)
+				return nil
+			})
+		} else {
+			cmd.Stderr = opts.Stderr
+		}
+	}
+	if err := cmd.Start(); err != nil {
+		cancel() // free resources
+		tb.Fatalf("failed to start %s: %v", name, err)
+	}
+
+	// Watch the process and cancel our context when it finishes.
+	var killed atomic.Bool
+	exitErr := make(chan error, 1)
+	go func() {
+		defer cancel()
+		err := cmd.Wait()
+		if err == nil || killed.Load() {
+			exitErr <- nil
+		} else {
+			exitErr <- err
+		}
+	}()
+
+	// Create a channel that we cancel when the test finishes, and use this
+	// to shut down our process.
+	testDone := make(chan struct{})
+	tb.Cleanup(func() {
+		close(testDone)
+
+		// Wait for the process to finish before letting the test exit.
+		<-ctx.Done()
+
+		// Read the exit error
+		if err := <-exitErr; err != nil {
+			tb.Errorf("process exited with error: %v", err)
+		}
+	})
+
+	if opts != nil && opts.ShutdownSignal != 0 {
+		shutdownTimeout := cmp.Or(opts.ShutdownTimeout, 2*time.Second)
+		go func() {
+			// Wait for the test to finish.
+			<-testDone
+
+			cmd.Process.Signal(syscall.SIGTERM)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(shutdownTimeout):
+			}
+			killed.Store(true)
+			cmd.Process.Kill()
+		}()
+	} else {
+		go func() {
+			<-testDone
+			killed.Store(true)
+			cmd.Process.Kill()
+		}()
+	}
+
+	return &Proc{
+		tb:  tb,
+		ctx: ctx,
+		cmd: cmd,
+	}
+}
+
+// Context returns a [context.Context] that is canceled when the monitored
+// process exits.
+func (p *Proc) Context() context.Context {
+	return p.ctx
+}
+
+// Wait runs the given function any number of times until either the timeout
+// elapses, the monitored process exits, or it returns a nil error.
+//
+// If the timeout elapses, the test will error.
+func (p *Proc) Wait(dur time.Duration, f func(context.Context) error) {
+	var lastErr error
+
+	remain := dur
+	for remain > 0 {
+		if err := p.ctx.Err(); err != nil {
+			// process done
+			return
+		}
+		if lastErr = f(p.ctx); lastErr == nil {
+			return
+		}
+
+		// TODO: nicer backoff than this
+		select {
+		case <-p.ctx.Done():
+			return // process done
+		case <-time.After(10 * time.Millisecond):
+		}
+		remain -= 10 * time.Millisecond
+	}
+
+	p.tb.Errorf("Wait did not succeed in %v; last error: %v", dur, lastErr)
+}
+
+// WaitForFiles will wait for the given files to exist on disk, using the Wait
+// function.
+func (p *Proc) WaitForFiles(dur time.Duration, files ...string) {
+	p.Wait(dur, func(_ context.Context) error {
+		var errs []error
+		for _, path := range files {
+			if _, err := os.Stat(path); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		return errors.Join(errs...)
+	})
+}
+
+// WaitForHttpOK will wait until a HTTP request to the provided address (using
+// the provided HTTP client) returns a 200 OK response. No further checking is
+// done; if anything more complicated is necessary, then a custom Wait function
+// can be used.
+func (p *Proc) WaitForHttpOK(dur time.Duration, client *http.Client, addr string) {
+	p.Wait(dur, func(ctx context.Context) error {
+		req, err := http.NewRequestWithContext(ctx, "GET", addr, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("bad status: %d", resp.StatusCode)
+		}
+
+		return nil
+	})
+}


### PR DESCRIPTION
See individual commits for more details, but essentially: this adds an integration test if the `caddy` binary is available in the `$PATH` that launches Caddy with `forward_auth` configured and validates that logging in and then accessing a protected resource succeeds.

Feel free to review as much or as little as you wish 😃 