### PR TITLE
sessions: add basic sessions package

### DIFF
--- a/sessions/memstore.go
+++ b/sessions/memstore.go
@@ -1,0 +1,114 @@
+package sessions
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+type memStoreData[T any] struct {
+	Data   T
+	Expiry time.Time
+	Token  string
+}
+
+// MemStore is an in-memory session store. It is safe for concurrent use.
+//
+// All methods that take or return a value of type T will perform a shallow
+// copy of the type into the provided input or output parameters.
+type MemStore[T any] struct {
+	mu       sync.RWMutex
+	sessions map[string]memStoreData[T]
+	timeNow  func() time.Time
+}
+
+// NewMemStore returns a new MemStore instance.
+func NewMemStore[T any]() *MemStore[T] {
+	return &MemStore[T]{
+		sessions: make(map[string]memStoreData[T]),
+		timeNow:  time.Now,
+	}
+}
+
+func (ms *MemStore[T]) keyFor(token string) string {
+	hash := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(hash[:])
+}
+
+// Find implements the Store interface.
+func (ms *MemStore[T]) Find(_ context.Context, token string, into *T) error {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+
+	data, ok := ms.sessions[ms.keyFor(token)]
+	if !ok {
+		return ErrNotFound
+	}
+
+	// Unlikely, but confirm that the token actually matches. This should
+	// never happen since we use a cryptographic hash.
+	if data.Token != token {
+		return ErrNotFound
+	}
+
+	now := ms.timeNow()
+	isExpired := data.Expiry.Before(now)
+	if isExpired {
+		return ErrNotFound
+	}
+
+	*into = data.Data
+	return nil
+}
+
+// Delete implements the Store interface.
+func (ms *MemStore[T]) Delete(_ context.Context, token string) error {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	delete(ms.sessions, ms.keyFor(token))
+	return nil
+}
+
+// Commit implements the Store interface.
+func (ms *MemStore[T]) Commit(_ context.Context, token string, d *T, expiry time.Time) error {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	ms.sessions[ms.keyFor(token)] = memStoreData[T]{
+		Data:   *d,
+		Expiry: expiry,
+		Token:  token,
+	}
+	return nil
+}
+
+// List implements the Store interface.
+func (ms *MemStore[T]) List(_ context.Context) (map[string]T, error) {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+
+	tokens := make(map[string]T, len(ms.sessions))
+	now := ms.timeNow()
+	for _, data := range ms.sessions {
+		if data.Expiry.Before(now) {
+			continue
+		}
+		tokens[data.Token] = data.Data
+	}
+	return tokens, nil
+}
+
+// CleanExpired removes all expired sessions from the store. It is the
+// responsibility of the user of the store to call this method periodically.
+func (ms *MemStore[T]) CleanExpired() {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+
+	now := ms.timeNow()
+	for key, data := range ms.sessions {
+		if data.Expiry.Before(now) {
+			delete(ms.sessions, key)
+		}
+	}
+}

--- a/sessions/memstore_test.go
+++ b/sessions/memstore_test.go
@@ -1,0 +1,169 @@
+package sessions
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func testStore[T any](t *testing.T, store Store[T], setTime func(time.Time)) {
+	var zero T
+
+	// Set the time to a fixed value.
+	now := time.Unix(1729223000, 0)
+	setTime(now)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const token = "token"
+
+	// Store a session.
+	if err := store.Commit(ctx, token, &zero, now.Add(time.Hour)); err != nil {
+		t.Fatalf("store.Commit failed: %v", err)
+	}
+
+	// Verify we can get the session.
+	var out T
+	if err := store.Find(ctx, token, &out); err != nil {
+		t.Logf("store: %#v", store)
+		t.Fatalf("store.Find failed: %v", err)
+	}
+
+	// Verify that we see it in the List output.
+	sessions, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("store.List failed: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected one session, got %d", len(sessions))
+	}
+	if _, ok := sessions[token]; !ok {
+		t.Fatalf("expected %q in sessions, got %v", token, sessions)
+	}
+
+	// Delete the session.
+	if err := store.Delete(ctx, token); err != nil {
+		t.Fatalf("store.Delete failed: %v", err)
+	}
+
+	// Verify that it's gone.
+	err = store.Find(ctx, token, &out)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	sessions, err = store.List(ctx)
+	if err != nil {
+		t.Fatalf("store.List failed: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("expected zero sessions, got %d", len(sessions))
+	}
+
+	// Verify that deleting it again isn't an error.
+	if err := store.Delete(ctx, token); err != nil {
+		t.Fatalf("store.Delete failed: %v", err)
+	}
+
+	t.Run("Expiry", func(t *testing.T) {
+		const token = "token-with-expiry"
+
+		// Insert a session with a short expiry.
+		expiry := now.Add(time.Second)
+		if err := store.Commit(ctx, token, &zero, expiry); err != nil {
+			t.Fatalf("store.Commit failed: %v", err)
+		}
+
+		// Move past the expiry.
+		setTime(expiry.Add(time.Second))
+
+		// Verify that the session is gone.
+		err = store.Find(ctx, token, &out)
+		if !errors.Is(err, ErrNotFound) {
+			t.Fatalf("expected ErrNotFound, got %v", err)
+		}
+
+		// Verify that it's gone from List.
+		sessions, err := store.List(ctx)
+		if err != nil {
+			t.Fatalf("store.List failed: %v", err)
+		}
+		if len(sessions) != 0 {
+			t.Fatalf("expected zero sessions, got %d", len(sessions))
+		}
+	})
+}
+
+func TestMemStore(t *testing.T) {
+	now := new(time.Time)
+	store := NewMemStore[int]()
+	store.timeNow = func() time.Time {
+		return *now
+	}
+	testStore(t, store, func(tm time.Time) {
+		*now = tm
+	})
+}
+
+func TestMemStore_CleanExpired(t *testing.T) {
+	now := new(time.Time)
+	store := NewMemStore[int]()
+	store.timeNow = func() time.Time {
+		return *now
+	}
+	*now = time.Unix(1729223000, 0)
+	ctx := context.Background()
+
+	// Insert a session with a short expiry.
+	const token = "token"
+	val := new(int)
+	if err := store.Commit(ctx, token, val, now.Add(time.Hour)); err != nil {
+		t.Fatalf("store.Commit failed: %v", err)
+	}
+
+	// Insert a session with a long expiry.
+	const longToken = "long-token"
+	longVal := new(int)
+	*longVal = 1
+	if err := store.Commit(ctx, longToken, longVal, now.Add(time.Hour*24)); err != nil {
+		t.Fatalf("store.Commit failed: %v", err)
+	}
+
+	// Move past the expiry time.
+	*now = now.Add(time.Hour).Add(time.Second)
+
+	// Verify that the session is gone.
+	var out int
+	err := store.Find(ctx, token, &out)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+
+	// Verify that the long-expiry session is still there.
+	if err := store.Find(ctx, longToken, &out); err != nil {
+		t.Fatalf("store.Find failed: %v", err)
+	}
+
+	// The expired session should still be in our store...
+	store.mu.RLock()
+	sessionsInStore := len(store.sessions)
+	store.mu.RUnlock()
+	if sessionsInStore != 2 {
+		t.Fatalf("expected two sessions in store, got %d", sessionsInStore)
+	}
+
+	// ... until we call CleanExpired
+	store.CleanExpired()
+	store.mu.RLock()
+	sessionsInStore = len(store.sessions)
+	store.mu.RUnlock()
+	if sessionsInStore != 1 {
+		t.Fatalf("expected 1 session in store, got %d", sessionsInStore)
+	}
+
+	// The long-expiry session should still be there after we clean.
+	if err := store.Find(ctx, longToken, &out); err != nil {
+		t.Fatalf("store.Find failed: %v", err)
+	}
+}

--- a/sessions/response_writer.go
+++ b/sessions/response_writer.go
@@ -1,0 +1,56 @@
+package sessions
+
+import "net/http"
+
+// sessionResponseWriter wraps http.ResponseWriter, but will commit any changes
+// to the session when the response is written.
+//
+// If an error occurs when we commit the session, we will "poison" the writer
+// so that it ignores any further writes. This is to prevent partially written
+// data from being sent to the client, and to ensure that we don't end up in a
+// half-broken state where the server thinks that the session is committed but
+// the client doesn't.
+type sessionResponseWriter[T any] struct {
+	http.ResponseWriter
+	req      *http.Request
+	mgr      *Manager[T]
+	written  bool
+	poisoned bool // if true, ignore all writes
+}
+
+func (srw *sessionResponseWriter[T]) Write(p []byte) (int, error) {
+	if srw.poisoned {
+		return len(p), nil
+	}
+	if !srw.written {
+		cont := srw.mgr.onResponse(srw.ResponseWriter, srw.req)
+		srw.written = true
+		if !cont {
+			srw.poisoned = true
+			return len(p), nil
+		}
+	}
+	return srw.ResponseWriter.Write(p)
+}
+
+func (srw *sessionResponseWriter[T]) WriteHeader(code int) {
+	if srw.poisoned {
+		return
+	}
+	if !srw.written {
+		cont := srw.mgr.onResponse(srw.ResponseWriter, srw.req)
+		srw.written = true
+		if !cont {
+			srw.poisoned = true
+			return
+		}
+	}
+	srw.ResponseWriter.WriteHeader(code)
+}
+
+// Unwrap allows [http.ResponseController] to access the underlying
+// [http.ResponseWriter], so that clients can call methods on the original
+// writer.
+func (srw *sessionResponseWriter[T]) Unwrap() http.ResponseWriter {
+	return srw.ResponseWriter
+}

--- a/sessions/sessions.go
+++ b/sessions/sessions.go
@@ -1,0 +1,358 @@
+package sessions
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+const sessionCookieName = "session"
+
+// ErrNotFound is returned by the Find method of a session store when the
+// requested session is not found.
+var ErrNotFound = errors.New("session not found")
+
+// Store is the interface that must be implemented by persistent session
+// stores. It is modeled after the session store interface in the scs package.
+// Each Store can define how it marshals and unmarshals the provided type
+// parameter T, if necessary.
+//
+// All methods must be safe for concurrent use.
+type Store[T any] interface {
+	// Find should return the data for a session token from the store,
+	// storing it into the 'into' parameter. If the session token is not
+	// found, tampered with, or is expired, the error return value should
+	// be ErrNotFound.
+	Find(ctx context.Context, token string, into *T) (err error)
+
+	// Delete should remove the session token and corresponding data from the
+	// store. If the token does not exist then Delete should do nothing and
+	// return nil (and not an error).
+	Delete(ctx context.Context, token string) (err error)
+
+	// Commit should add the session token and data to the store, with the
+	// given expiry time. If the session token already exists, then the
+	// data and expiry time should be overwritten.
+	Commit(ctx context.Context, token string, d *T, expiry time.Time) (err error)
+
+	// List should return a list of all valid, non-expired session tokens
+	// in the store along with their data.
+	List(ctx context.Context) (tokens map[string]T, err error)
+}
+
+// CookieOpts is a struct that can be used to configure the session cookie.
+//
+// A Manager is constructed with a default CookieOpts struct, so you only need
+// to modify these values if you want to change the defaults.
+type CookieOpts struct {
+	// Name is the name of the session cookie. The default is "session".
+	Name string
+	// Domain is the domain of the session cookie. By default, the domain is
+	// the domain the domain that the HTTP request was made to.
+	Domain string
+	// Path is the path of the session cookie. The default is "/".
+	Path string
+	// Secure indicates if the session cookie should only be sent over
+	// HTTPS. The default is false.
+	Secure bool
+	// HttpOnly indicates if the session cookie should be accessible only
+	// to the server via HTTP (i.e. not in JavaScript). The default is true.
+	HttpOnly bool
+	// SameSite indicates the SameSite attribute of the session cookie. The
+	// default is http.SameSiteStrictMode..
+	SameSite http.SameSite
+}
+
+// Manager stores and provides accessors for session data for HTTP clients, via
+// an opaque token in a cookie that acts as a key for a persistent session data
+// store.
+//
+// The type parameter T is the type of the session data. It must be possible to
+// copy with a shallow copy, since shallow copies are returned from the Get
+// method and used to update the session data in the Update method.
+type Manager[T any] struct {
+	ps      Store[T]
+	timeNow func() time.Time
+
+	// Log is the logger used by the session manager. It must be provided,
+	// and the default value is slog.Default().
+	Log *slog.Logger
+
+	// CookieOpts is the configuration for the session cookie.
+	// This field cannot be modified when the Manager is in use.
+	CookieOpts CookieOpts
+
+	// Lifetime is how long a session should last. The default is 7 days.
+	Lifetime time.Duration
+}
+
+// New creates a new session manager that uses the provided session store.
+func New[T any](ps Store[T]) (*Manager[T], error) {
+	ret := &Manager[T]{
+		ps:      ps,
+		timeNow: time.Now,
+		Log:     slog.Default(),
+		CookieOpts: CookieOpts{
+			Name:     sessionCookieName,
+			Path:     "/",
+			Secure:   false,
+			HttpOnly: true,
+			SameSite: http.SameSiteStrictMode,
+		},
+		Lifetime: 7 * 24 * time.Hour,
+	}
+	return ret, nil
+}
+
+// Middleware returns a middleware function that can be used to wrap HTTP
+// handlers. The middleware will automatically load and save the session data
+// for each request.
+func (m *Manager[T]) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Vary", "Cookie")
+
+		// TODO: pool?
+		sd := &sessionData[T]{
+			state: stateNew, // new = not loaded from the session store
+		}
+
+		// First, load the session data from the request.
+		if cookie, err := r.Cookie(m.CookieOpts.Name); err == nil {
+			// Load from store.
+			if err := m.ps.Find(r.Context(), cookie.Value, &sd.Data); err != nil {
+				if !errors.Is(err, ErrNotFound) {
+					// If we have an error other than "not found", log it.
+					m.Log.Error("error loading persistent session", "error", err)
+
+					// Also clear the session data.
+					var zero T
+					sd.Data = zero
+				}
+			} else {
+				sd.token = cookie.Value
+				sd.state = stateLoaded
+			}
+		}
+
+		// Store the session data in the request context.
+		ctx := context.WithValue(r.Context(), contextKey, sd)
+		r = r.WithContext(ctx)
+
+		// Wrap the response writer to commit the session data before
+		// we write data to the client.
+		srw := &sessionResponseWriter[T]{
+			ResponseWriter: w,
+			req:            r,
+			mgr:            m,
+		}
+
+		next.ServeHTTP(srw, r)
+
+		// Commit the session data if it hasn't been done already.
+		if !srw.written {
+			m.onResponse(srw.ResponseWriter, srw.req)
+		}
+	})
+}
+
+// onResponse is called before the response is written to the client.
+//
+// It returns whether or not to continue writing the response to the client,
+// which is false if an error occurred when saving the session data.
+func (m *Manager[T]) onResponse(w http.ResponseWriter, r *http.Request) bool {
+	ctx := r.Context()
+
+	sd, ok := ctx.Value(contextKey).(*sessionData[T])
+	if !ok {
+		m.Log.Error("session data not found in request context")
+		return true
+	}
+
+	switch sd.state {
+	case stateDeleted:
+		if err := m.ps.Delete(ctx, sd.token); err != nil {
+			m.Log.Error("error deleting session", "error", err)
+
+			status := http.StatusInternalServerError
+			http.Error(w, http.StatusText(status), status)
+			return false
+		}
+
+		// Delete the session cookie.
+		m.deleteCookie(w, sd.token)
+
+	case stateModified:
+		// Commit the session data to the store.
+		expiry := m.timeNow().Add(m.Lifetime)
+		if err := m.ps.Commit(ctx, sd.token, &sd.Data, expiry); err != nil {
+			m.Log.Error("error committing session", "token", sd.token, "error", err)
+
+			// Write an error to the client instead of leaving
+			// things in a broken state.
+			status := http.StatusInternalServerError
+			http.Error(w, http.StatusText(status), status)
+			return false
+		}
+
+		// Set the session cookie.
+		m.setCookie(w, sd.token)
+
+	case stateUnknown:
+		m.Log.Warn("session state is unknown", "token", sd.token)
+	}
+
+	return true
+}
+
+func (m *Manager[T]) deleteCookie(w http.ResponseWriter, token string) {
+	cookie := &http.Cookie{
+		Name:     m.CookieOpts.Name,
+		Value:    "", // clear the value
+		Path:     m.CookieOpts.Path,
+		Domain:   m.CookieOpts.Domain,
+		MaxAge:   -1, // negative = delete
+		HttpOnly: m.CookieOpts.HttpOnly,
+		SameSite: m.CookieOpts.SameSite,
+		Secure:   m.CookieOpts.Secure,
+	}
+	http.SetCookie(w, cookie)
+}
+
+func (m *Manager[T]) setCookie(w http.ResponseWriter, token string) {
+	cookie := &http.Cookie{
+		Name:     m.CookieOpts.Name,
+		Value:    token,
+		Path:     m.CookieOpts.Path,
+		Domain:   m.CookieOpts.Domain,
+		MaxAge:   int(m.Lifetime.Seconds()),
+		HttpOnly: m.CookieOpts.HttpOnly,
+		SameSite: m.CookieOpts.SameSite,
+		Secure:   m.CookieOpts.Secure,
+	}
+	http.SetCookie(w, cookie)
+	w.Header().Add("Cache-Control", `no-cache="Set-Cookie"`)
+}
+
+var contextKey = new(int)
+
+type sessionState int
+
+const (
+	stateUnknown  sessionState = 0 // session status is unknown
+	stateNew      sessionState = 1 // session is newly created, but not yet modified
+	stateLoaded   sessionState = 2 // session is loaded from the store, but not yet modified
+	stateModified sessionState = 3 // session has been modified
+	stateDeleted  sessionState = 4 // session has been deleted
+)
+
+func (s sessionState) String() string {
+	switch s {
+	case stateUnknown:
+		return "unknown"
+	case stateNew:
+		return "new"
+	case stateLoaded:
+		return "loaded"
+	case stateModified:
+		return "modified"
+	case stateDeleted:
+		return "deleted"
+	default:
+		return "invalid"
+	}
+}
+
+// sessionData is the type of the session data stored in the request context.
+type sessionData[T any] struct {
+	// Data is the actual session data.
+	Data T
+
+	// token is the session token that was used to load the session data.
+	token string
+
+	// state is the current state of the session data.
+	state sessionState
+}
+
+// Get will return the session data stored in the provided request context. If
+// there is no session data in the context, then Get will return the zero value
+// of the session data type and false.
+//
+// Note that even if T is a pointer type, the session will not be updated or
+// persisted if modified; you must call Update to save the changes.
+func (m *Manager[T]) Get(ctx context.Context) (T, bool) {
+	sd, ok := ctx.Value(contextKey).(*sessionData[T])
+	if !ok {
+		var zero T
+		return zero, false
+	}
+	if sd.state != stateLoaded && sd.state != stateModified {
+		var zero T
+		return zero, false
+	}
+	return sd.Data, true
+}
+
+// Update will call the provided function to update the session data in the
+// request context. When the request is written to the client, the session data
+// will be updated in the session store and the session cookie will be set.
+//
+// If the called function returns a non-nil error, then the session data will
+// not be updated.
+//
+// The provided function will be called with a shallow copy of the session data,
+// which will be copied back into the session data stored in the request context
+// if the function returns nil. It is the responsibility of the function to
+// ensure that any nested pointers are only updated and not mutated in-place;
+// otherwise, if the called function returns an error, the session data may be
+// left in an inconsistent state.
+func (m *Manager[T]) Update(ctx context.Context, f func(*T) error) error {
+	sd, ok := ctx.Value(contextKey).(*sessionData[T])
+	if !ok {
+		return errors.New("session data not found in request context")
+	}
+
+	// Make a token for this session if we haven't already.
+	if sd.token == "" {
+		var buf [32]byte
+		if _, err := rand.Read(buf[:]); err != nil {
+			panic(err) // never fails on modern Go systems
+		}
+		sd.token = hex.EncodeToString(buf[:])
+	}
+
+	// Shallow-copy the session data so that, if the function fails, we
+	// don't overwrite any previously-updated data.
+	dataCopy := sd.Data
+	if err := f(&dataCopy); err != nil {
+		return err
+	}
+
+	sd.Data = dataCopy
+	sd.state = stateModified
+	return nil
+}
+
+// Delete will remove the session data from the request context. The session
+// data will not be removed from the session store until the response is
+// written to the client.
+//
+// If Delete is called and then Update is called, the session data will be
+// written to the session store as if it were new data.
+func (m *Manager[T]) Delete(ctx context.Context) {
+	sd, ok := ctx.Value(contextKey).(*sessionData[T])
+	if !ok {
+		return
+	}
+
+	sd.state = stateDeleted
+
+	// Also zero out the stored session data, so a future call to Update
+	// will operate on the zero value.
+	var zero T
+	sd.Data = zero
+}

--- a/sessions/sessions_go120_test.go
+++ b/sessions/sessions_go120_test.go
@@ -1,0 +1,29 @@
+//go:build go1.20
+// +build go1.20
+
+package sessions
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// NOTE: test file is Go 1.20+ so we can use [http.ResponseController].
+
+func TestResponseWriterImplementsFlush(t *testing.T) {
+	mgr := newTestManager(t)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/flush", func(w http.ResponseWriter, r *http.Request) {
+		rc := http.NewResponseController(w)
+		fmt.Fprint(w, "initial\n")
+		if err := rc.Flush(); err != nil {
+			t.Errorf("Flush failed: %v", err)
+			return
+		}
+		fmt.Fprint(w, "flushed")
+	})
+
+	testSrv := runTestServer(t, mgr, mux)
+	testSrv.assertResponse("/flush", http.StatusOK, "initial\nflushed")
+}

--- a/sessions/sessions_test.go
+++ b/sessions/sessions_test.go
@@ -1,0 +1,460 @@
+package sessions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/neilotoole/slogt"
+	"golang.org/x/net/publicsuffix"
+)
+
+type testSessionData struct {
+	UID     int
+	IsAdmin bool
+	Counter int
+}
+
+func newTestManager(tb testing.TB) *Manager[testSessionData] {
+	tb.Helper()
+	store := NewMemStore[testSessionData]()
+	mgr, err := New(&loggingStore[testSessionData]{tb, store})
+	if err != nil {
+		tb.Fatalf("could not create session manager: %v", err)
+	}
+	mgr.Log = slogt.New(tb)
+	return mgr
+}
+
+type testServer struct {
+	*httptest.Server
+	t      *testing.T
+	client *http.Client
+}
+
+func runTestServer[T any](t *testing.T, mgr *Manager[T], h http.Handler) *testServer {
+	testSrv := httptest.NewServer(mgr.Middleware(h))
+	t.Cleanup(testSrv.Close)
+	client := testSrv.Client()
+
+	jar, err := cookiejar.New(&cookiejar.Options{
+		PublicSuffixList: publicsuffix.List,
+	})
+	if err != nil {
+		t.Fatalf("could not create cookie jar: %v", err)
+	}
+	client.Jar = jar
+	return &testServer{
+		Server: testSrv,
+		t:      t,
+		client: client,
+	}
+}
+
+func (t *testServer) assertResponse(url string, wantStatus int, wantBody string) {
+	t.t.Helper()
+	resp, err := t.client.Get(t.Server.URL + url)
+	if err != nil {
+		t.t.Fatalf("could not get %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != wantStatus {
+		t.t.Errorf("%s: status = %d; want %d", url, resp.StatusCode, wantStatus)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.t.Fatalf("could not read body: %v", err)
+	}
+	if string(body) != wantBody {
+		t.t.Errorf("%s: body = %q; want %q", url, body, wantBody)
+	}
+}
+
+func (t *testServer) setCookie(cookie *http.Cookie) {
+	uu, _ := url.Parse(t.Server.URL)
+	t.client.Jar.SetCookies(uu, []*http.Cookie{cookie})
+}
+
+func TestBasicSessionHandling(t *testing.T) {
+	mgr := newTestManager(t)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		mgr.Update(r.Context(), func(d *testSessionData) error {
+			d.UID = 123
+			d.IsAdmin = true
+			return nil
+		})
+		w.Write([]byte("logged in\n"))
+	})
+	mux.HandleFunc("/logout", func(w http.ResponseWriter, r *http.Request) {
+		mgr.Delete(r.Context())
+		w.Write([]byte("logged out\n"))
+	})
+	mux.HandleFunc("/profile", func(w http.ResponseWriter, r *http.Request) {
+		session, ok := mgr.Get(r.Context())
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("unauthorized\n"))
+			return
+		}
+		fmt.Fprintf(w, "UID: %d\n", session.UID)
+		fmt.Fprintf(w, "IsAdmin: %v\n", session.IsAdmin)
+		fmt.Fprintf(w, "Counter: %d\n", session.Counter)
+	})
+	mux.HandleFunc("/no-response", func(w http.ResponseWriter, r *http.Request) {
+		if err := mgr.Update(r.Context(), func(d *testSessionData) error {
+			d.Counter++
+			return nil
+		}); err != nil {
+			t.Errorf("could not update session: %v", err)
+		}
+
+		// Explicitly do not write anything to the response.
+	})
+
+	testSrv := runTestServer(t, mgr, mux)
+
+	// Test unauthorized access
+	testSrv.assertResponse("/profile", http.StatusUnauthorized, "unauthorized\n")
+
+	// Log in
+	testSrv.assertResponse("/login", http.StatusOK, "logged in\n")
+
+	// Test authorized access
+	testSrv.assertResponse("/profile", http.StatusOK, "UID: 123\nIsAdmin: true\nCounter: 0\n")
+
+	// Test session update without response
+	testSrv.assertResponse("/no-response", http.StatusOK, "")
+	testSrv.assertResponse("/profile", http.StatusOK, "UID: 123\nIsAdmin: true\nCounter: 1\n")
+
+	// Verify that we have a session in our store.
+	sessions, err := mgr.ps.List(context.Background())
+	if err != nil {
+		t.Fatalf("could not list sessions: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session; got %d", len(sessions))
+	}
+	for token, session := range sessions {
+		if session.UID != 123 {
+			t.Errorf("session %q: UID = %d; want 123", token, session.UID)
+		}
+		break // only one session
+	}
+
+	// Log out
+	testSrv.assertResponse("/logout", http.StatusOK, "logged out\n")
+
+	// Test unauthorized access again
+	testSrv.assertResponse("/profile", http.StatusUnauthorized, "unauthorized\n")
+
+	// Test unauthorized access with an invalid session token.
+	testSrv.setCookie(&http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "invalid",
+		Path:     "/",
+		HttpOnly: true,
+	})
+	testSrv.assertResponse("/profile", http.StatusUnauthorized, "unauthorized\n")
+}
+
+func TestDeleteThenUpdate(t *testing.T) {
+	mgr := newTestManager(t)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/create-session", func(w http.ResponseWriter, r *http.Request) {
+		if err := mgr.Update(r.Context(), func(d *testSessionData) error {
+			d.UID = 123
+			return nil
+		}); err != nil {
+			t.Errorf("could not create session: %v", err)
+			return
+		}
+		w.Write([]byte("created session\n"))
+	})
+	mux.HandleFunc("/delete-then-update", func(w http.ResponseWriter, r *http.Request) {
+		mgr.Delete(r.Context())
+		if err := mgr.Update(r.Context(), func(d *testSessionData) error {
+			d.UID = 456
+			return nil
+		}); err != nil {
+			t.Errorf("could not update session: %v", err)
+			return
+		}
+		w.Write([]byte("deleted then updated\n"))
+	})
+	mux.HandleFunc("/profile", func(w http.ResponseWriter, r *http.Request) {
+		session, ok := mgr.Get(r.Context())
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("unauthorized\n"))
+			return
+		}
+		fmt.Fprintf(w, "UID: %d\n", session.UID)
+	})
+
+	testSrv := runTestServer(t, mgr, mux)
+	testSrv.assertResponse("/create-session", http.StatusOK, "created session\n")
+	testSrv.assertResponse("/profile", http.StatusOK, "UID: 123\n")
+	testSrv.assertResponse("/delete-then-update", http.StatusOK, "deleted then updated\n")
+	testSrv.assertResponse("/profile", http.StatusOK, "UID: 456\n")
+}
+
+func TestUpdateShallowCopies(t *testing.T) {
+	mgr := newTestManager(t)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/update-success", func(w http.ResponseWriter, r *http.Request) {
+		if err := mgr.Update(r.Context(), func(d *testSessionData) error {
+			d.Counter++
+			return nil
+		}); err != nil {
+			t.Errorf("unexpected error: %v", err)
+			return
+		}
+		w.Write([]byte("updated\n"))
+	})
+	mux.HandleFunc("/update-failure", func(w http.ResponseWriter, r *http.Request) {
+		// The first one will succeed.
+		mgr.Update(r.Context(), func(d *testSessionData) error {
+			d.Counter++
+			return nil
+		})
+
+		// The second one will fail.
+		mgr.Update(r.Context(), func(d *testSessionData) error {
+			d.Counter++
+			return errors.New("update failed")
+		})
+		w.Write([]byte("not updated\n"))
+	})
+	mux.HandleFunc("/get", func(w http.ResponseWriter, r *http.Request) {
+		session, _ := mgr.Get(r.Context())
+		fmt.Fprintf(w, "Counter: %d\n", session.Counter)
+	})
+
+	testSrv := runTestServer(t, mgr, mux)
+	testSrv.assertResponse("/update-success", http.StatusOK, "updated\n")
+	testSrv.assertResponse("/get", http.StatusOK, "Counter: 1\n")
+	testSrv.assertResponse("/update-failure", http.StatusOK, "not updated\n")
+	testSrv.assertResponse("/get", http.StatusOK, "Counter: 2\n") // first update succeeded, second failed
+}
+
+func TestSessionBadContext(t *testing.T) {
+	mgr := newTestManager(t)
+
+	ctx := context.Background()
+	if _, ok := mgr.Get(ctx); ok {
+		t.Error("Get with empty context returned a session")
+	}
+	mgr.Delete(ctx) // no error, but no panic
+
+	err := mgr.Update(ctx, func(d *testSessionData) error {
+		return nil
+	})
+	if err == nil {
+		t.Error("Update with empty context did not return an error")
+	}
+}
+
+func TestUpdatePropagatesError(t *testing.T) {
+	mgr := newTestManager(t)
+
+	testErr := errors.New("test error")
+
+	// Make a fake context with bare session data.
+	ctx := context.WithValue(context.Background(), contextKey, &sessionData[testSessionData]{
+		state: stateNew,
+	})
+
+	err := mgr.Update(ctx, func(d *testSessionData) error {
+		return testErr
+	})
+	if !errors.Is(err, testErr) {
+		t.Errorf("Update did not propagate error: %v", err)
+	}
+}
+
+func TestUpdateNested_Bad(t *testing.T) {
+	// NOTE: this is an example of what *not* to do; we mutate a nested
+	// pointer here which causes the second Update to fail to roll back.
+
+	type nestedPtr struct {
+		Inner *int
+	}
+	store := NewMemStore[nestedPtr]()
+	mgr, err := New(&loggingStore[nestedPtr]{t, store})
+	if err != nil {
+		t.Fatalf("could not create session manager: %v", err)
+	}
+	mgr.Log = slogt.New(t)
+
+	// Make a fake context with bare session data.
+	ctx := context.WithValue(context.Background(), contextKey, &sessionData[nestedPtr]{
+		state: stateNew,
+	})
+
+	// First update; this succeeds.
+	if err := mgr.Update(ctx, func(d *nestedPtr) error {
+		if d.Inner == nil {
+			d.Inner = new(int)
+		}
+		*d.Inner = *d.Inner + 1
+		return nil
+	}); err != nil {
+		t.Fatalf("could not update: %v", err)
+	}
+
+	// Second update; this fails, but we update the nested pointer which we
+	// don't deep copy.
+	if err := mgr.Update(ctx, func(d *nestedPtr) error {
+		if d.Inner == nil {
+			d.Inner = new(int)
+		}
+		*d.Inner = *d.Inner + 1 // BAD BAD BAD ❌
+		return errors.New("update failed")
+	}); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	// The second update failed, but the nested pointer was updated.
+	session, _ := mgr.Get(ctx)
+	if *session.Inner != 2 {
+		t.Errorf("nested pointer = %d; want 2", *session.Inner)
+	}
+
+	// This is the safe way to do it.
+	if err := mgr.Update(ctx, func(d *nestedPtr) error {
+		var val int
+		if d.Inner != nil {
+			val = *d.Inner
+		}
+		val++
+		d.Inner = &val // GOOD ✅
+		return errors.New("update failed")
+	}); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	// The third update failed, and the nested pointer was not updated.
+	session, _ = mgr.Get(ctx)
+	if *session.Inner != 2 {
+		t.Errorf("nested pointer = %d; want 2", *session.Inner)
+	}
+}
+
+func TestStoreErrors(t *testing.T) {
+	testErr := errors.New("test error")
+	mgr, err := New(&loggingStore[testSessionData]{
+		t,
+		errorStore[testSessionData]{testErr},
+	})
+	if err != nil {
+		t.Fatalf("could not create session manager: %v", err)
+	}
+	mgr.Log = slogt.New(t)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		if err := mgr.Update(r.Context(), func(d *testSessionData) error {
+			d.UID = 123
+			return nil
+		}); err != nil {
+			t.Errorf("Update should not error: %v", err)
+			return
+		}
+
+		switch up := r.URL.Query().Get("method"); up {
+		case "write":
+			// The following write will not be seen by the client, because
+			// the store will fail to persist our write, then the
+			// ResponseWriter is poisoned and ignores writes after an
+			// error.
+			w.Write([]byte("Update error\n"))
+
+			// The follow-up writes also don't get written.
+			w.Write([]byte("more data\n"))
+		case "write-header":
+			// This will trigger an error in the ResponseWriter.
+			w.WriteHeader(http.StatusCreated)
+
+			// Further writes will be ignored.
+			w.WriteHeader(http.StatusAccepted)
+		}
+	})
+	mux.HandleFunc("/delete", func(w http.ResponseWriter, r *http.Request) {
+		// No return error, but errors on Write/WriteHeader.
+		mgr.Delete(r.Context())
+	})
+	mux.HandleFunc("/profile", func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := mgr.Get(r.Context()); !ok {
+			w.Write([]byte("no session\n"))
+			return
+		}
+		w.Write([]byte("session\n"))
+	})
+
+	testSrv := runTestServer(t, mgr, mux)
+	testSrv.assertResponse("/login?method=write", http.StatusInternalServerError, "Internal Server Error\n")
+	testSrv.assertResponse("/login?method=write-header", http.StatusInternalServerError, "Internal Server Error\n")
+	testSrv.assertResponse("/profile", http.StatusOK, "no session\n") // since Find returns error
+	testSrv.assertResponse("/delete", http.StatusInternalServerError, "Internal Server Error\n")
+}
+
+func TestStateString(t *testing.T) {
+	for _, state := range []sessionState{
+		stateUnknown,
+		stateNew,
+		stateLoaded,
+		stateModified,
+		stateDeleted,
+		sessionState(999), // invalid
+	} {
+		if state.String() == "" {
+			t.Errorf("state %v: empty string", state)
+		}
+	}
+}
+
+type loggingStore[T any] struct {
+	tb    testing.TB
+	inner Store[T]
+}
+
+func (ls *loggingStore[T]) Find(ctx context.Context, token string, into *T) error {
+	err := ls.inner.Find(ctx, token, into)
+	ls.tb.Logf("Find(%q) = %v", token, err)
+	return err
+}
+
+func (ls *loggingStore[T]) Delete(ctx context.Context, token string) error {
+	err := ls.inner.Delete(ctx, token)
+	ls.tb.Logf("Delete(%q) = %v", token, err)
+	return err
+}
+
+func (ls *loggingStore[T]) Commit(ctx context.Context, token string, d *T, expiry time.Time) error {
+	err := ls.inner.Commit(ctx, token, d, expiry)
+	ls.tb.Logf("Commit(%q, %+v, %v) = %v", token, d, expiry.Format(time.RFC3339), err)
+	return err
+}
+
+func (ls *loggingStore[T]) List(ctx context.Context) (map[string]T, error) {
+	ret, err := ls.inner.List(ctx)
+	ls.tb.Logf("List() = (%d, %v)", len(ret), err)
+	return ret, err
+}
+
+type errorStore[T any] struct {
+	err error
+}
+
+func (es errorStore[T]) Find(context.Context, string, *T) error              { return es.err }
+func (es errorStore[T]) Delete(context.Context, string) error                { return es.err }
+func (es errorStore[T]) List(context.Context) (map[string]T, error)          { return nil, es.err }
+func (es errorStore[T]) Commit(context.Context, string, *T, time.Time) error { return es.err }


### PR DESCRIPTION
This adds a basic, first-party sessions package that uses Go generics to store structured data in a request's Context. It's inspired by both scs and the gorilla/sessions package, but is intentionally simpler (e.g. multiple stores are unsupported), typed, and minimal.

Updates #4