### PR TITLE
cmd/homeauth: stop using sessions for WebAuthn login

### DIFF
--- a/cmd/homeauth/oidc_test.go
+++ b/cmd/homeauth/oidc_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/neilotoole/slogt"
 
 	"github.com/andrew-d/homeauth/internal/db"
@@ -77,12 +76,6 @@ func newTestServer(tb testing.TB) (*idpServer, *httptest.Server) {
 		timeNow: time.Now,
 	}
 
-	wconfig := makeWebAuthnConfig(srv.URL)
-	webAuthn, err := webauthn.New(wconfig)
-	if err != nil {
-		tb.Fatalf("failed to create WebAuthn config: %v", err)
-	}
-
 	te, err := templates.New(slogt.New(tb).With("service", "templateEngine"))
 	if err != nil {
 		tb.Fatalf("failed to initialize template engine: %v", err)
@@ -95,7 +88,6 @@ func newTestServer(tb testing.TB) (*idpServer, *httptest.Server) {
 		sessions:       smgr,
 		db:             database,
 		hasher:         pwhash.New(2, 512*1024, 2),
-		webAuthn:       webAuthn,
 		templates:      te,
 	}
 	if err := idp.initializeConfig(); err != nil {

--- a/cmd/homeauth/webauthn.go
+++ b/cmd/homeauth/webauthn.go
@@ -3,32 +3,23 @@ package main
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/andrew-d/homeauth/internal/db"
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/gorilla/csrf"
+	"golang.org/x/crypto/chacha20poly1305"
 )
 
 func (s *idpServer) serveWebauthnBeginLogin(w http.ResponseWriter, r *http.Request) {
-	// Use sessionFromContextOpts to allow unauthenticated sessions.
-	session, ok := s.sessionFromContextOpts(r.Context(), sessionFromContextOpts{
-		AllowUnauthenticated: true,
-	})
-	if !ok {
-		panic("expected unauthenticated session to exist")
-	}
-
-	s.logger.Debug("beginning WebAuthn login",
-		"unauthenticated_session_id", session.ID,
-	)
+	s.logger.Debug("beginning WebAuthn login")
 
 	var requestBody struct {
 		Username string `json:"username"`
@@ -63,57 +54,43 @@ func (s *idpServer) serveWebauthnBeginLogin(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Store the session data in the session, and persist it.
-	if err := s.db.Write(func(data *data) error {
-		session = data.Sessions[session.ID] // re-load the session
-		session.WebAuthnSession = sessionData
-		return nil
-	}); err != nil {
-		s.logger.Error("failed to store session data", errAttr(err))
+	encodedSession, err := s.encodeWebAuthnSession(user.Email, sessionData)
+	if err != nil {
+		s.logger.Error("failed to encode WebAuthn session data", errAttr(err))
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 
 	// Return the registration data to the client.
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(options); err != nil {
-		s.logger.Error("failed to encode options", errAttr(err))
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"options": options,
+		"session": encodedSession,
+	}); err != nil {
+		s.logger.Error("failed to JSON-encode WebAuthn response", errAttr(err))
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 }
 
 func (s *idpServer) servePostLoginWebauthn(w http.ResponseWriter, r *http.Request, user *db.User) {
-	// Use sessionFromContextOpts to allow unauthenticated sessions.
-	session, ok := s.sessionFromContextOpts(r.Context(), sessionFromContextOpts{
-		AllowUnauthenticated: true,
-	})
-	if !ok {
-		panic("expected unauthenticated session to exist")
+	// Decode the session data from the form.
+	encryptedSession := r.FormValue("webauthn_session")
+	if encryptedSession == "" {
+		s.logger.Error("missing webauthn_session")
+		http.Error(w, "missing webauthn_session", http.StatusBadRequest)
+		return
 	}
-
-	s.logger.Debug("finishing WebAuthn login",
-		"unauthenticated_session_id", session.ID,
-		"user", user.Email,
-		"session_has_webauthn", session.WebAuthnSession != nil,
-	)
-
-	// If this session doesn't have a WebAuthn session, something is wrong;
-	// just redirect the user back to the login page (while preserving the 'next' URL parameter).
-	if session.WebAuthnSession == nil {
-		vals := url.Values{}
-		if nn := r.FormValue("next"); nn != "" {
-			vals.Set("next", nn)
-		}
-
-		s.logger.Warn("session missing WebAuthn session; redirecting to login")
-		http.Redirect(w, r, "/login?="+vals.Encode(), http.StatusSeeOther)
+	var sessionData webauthn.SessionData
+	if err := s.decodeWebAuthnSession(&sessionData, user.Email, encryptedSession); err != nil {
+		s.logger.Error("failed to decode WebAuthn session", errAttr(err))
+		http.Error(w, "invalid webauthn_session", http.StatusBadRequest)
 		return
 	}
 
-	var (
-		wuser *webAuthnUser
-	)
+	s.logger.Debug("finishing WebAuthn login", "user", user.Email)
+
+	var wuser *webAuthnUser
 	s.db.Read(func(data *data) {
 		wuser = s.makeWebAuthnUser(data, user)
 	})
@@ -136,7 +113,7 @@ func (s *idpServer) servePostLoginWebauthn(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	cred, err := s.webAuthn.ValidateLogin(wuser, *session.WebAuthnSession, par)
+	cred, err := s.webAuthn.ValidateLogin(wuser, sessionData, par)
 	if err != nil {
 		s.logger.Error("failed to validate webauthn response", errAttr(err))
 		http.Error(w, "invalid webauthn_response", http.StatusBadRequest)
@@ -182,6 +159,75 @@ func (s *idpServer) servePostLoginWebauthn(w http.ResponseWriter, r *http.Reques
 	}
 
 	http.Redirect(w, r, s.getNextURL(r), http.StatusSeeOther)
+}
+
+// appendWebAuthnSessionAD appends the associated data for an encrypted
+// WebAuthn session to out.
+//
+// The associated data that we use to includes a fixed string and then the
+// user's email, which adds further protection against session data being
+// confused between users.
+func appendWebAuthnSessionAD(out []byte, user string) []byte {
+	out = append(out, []byte("webauthn-session-data\x00")...)
+	out = append(out, []byte(user)...)
+	return out
+}
+
+func (s *idpServer) encodeWebAuthnSession(user string, sessionData *webauthn.SessionData) (string, error) {
+	// Encrypt the session data and send it to the client; we expect that
+	// the client will return it as-is without modification during the
+	// login POST request.
+	sessionBytes, err := json.Marshal(sessionData)
+	if err != nil {
+		return "", fmt.Errorf("marshaling session data: %w", err)
+	}
+
+	// Generate random nonce; should never fail because rand.Read doesn't
+	// return an error on modern systems / with modern Go.
+	var nonce [chacha20poly1305.NonceSizeX]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		panic(err)
+	}
+
+	// Encrypt, then append nonce to encrypted bytes.
+	associatedData := appendWebAuthnSessionAD(nil, user)
+	encBytes := s.webAuthnAEAD.Seal(sessionBytes[:0], nonce[:], sessionBytes, associatedData)
+	encBytes = append(encBytes, nonce[:]...)
+
+	// Encode to base64
+	b64 := base64.URLEncoding.EncodeToString(encBytes)
+	return b64, nil
+}
+
+func (s *idpServer) decodeWebAuthnSession(into *webauthn.SessionData, user, encoded string) error {
+	encBytes, err := base64.URLEncoding.DecodeString(encoded)
+	if err != nil {
+		return fmt.Errorf("decoding base64: %w", err)
+	}
+
+	// Remove nonce from the end of the data
+	if len(encBytes) <= chacha20poly1305.NonceSizeX {
+		s.logger.Error("invalid webauthn_session: too short",
+			"length", len(encBytes),
+			"nonce_size", chacha20poly1305.NonceSizeX,
+		)
+		return fmt.Errorf("invalid WebAuthn session: too short")
+	}
+	nonce := encBytes[len(encBytes)-chacha20poly1305.NonceSizeX:]
+	encBytes = encBytes[:len(encBytes)-chacha20poly1305.NonceSizeX]
+
+	// Decrypt the session data.
+	associatedData := appendWebAuthnSessionAD(nil, user)
+	plaintext, err := s.webAuthnAEAD.Open(encBytes[:0], nonce[:], encBytes, associatedData)
+	if err != nil {
+		return fmt.Errorf("decrypting WebAuthn session data: %w", err)
+	}
+
+	// Deserialize the session data.
+	if err := json.Unmarshal(plaintext, into); err != nil {
+		return fmt.Errorf("unmarshaling WebAuthn session data: %w", err)
+	}
+	return nil
 }
 
 func (s *idpServer) serveWebAuthn(w http.ResponseWriter, r *http.Request) {

--- a/cmd/homeauth/webauthn_test.go
+++ b/cmd/homeauth/webauthn_test.go
@@ -107,8 +107,8 @@ func TestWebauthnLogin(t *testing.T) {
 		}
 
 		// Start a login as an unauthenticated user with no session; this
-		// should result in the Webauthn session data being stored in the
-		// ephemeral session.
+		// should return both the WebAuthn options and an opaque
+		// session blob that we have to pass back to the server.
 		respBytes := tcPostJSON[*webauthnStartBody, json.RawMessage](client,
 			server.URL+"/login/webauthn",
 			&webauthnStartBody{
@@ -117,51 +117,27 @@ func TestWebauthnLogin(t *testing.T) {
 			withCSRFToken(csrfToken),
 		)
 
-		var resp protocol.CredentialAssertion
+		var resp struct {
+			Options protocol.CredentialAssertion `json:"options"`
+			Session string                       `json:"session"`
+		}
 		if err := json.Unmarshal(respBytes, &resp); err != nil {
 			t.Fatalf("failed to unmarshal response: %v", err)
 		}
 
 		// Basic sanity check on the response.
-		if want := rp.ID; resp.Response.RelyingPartyID != want {
-			t.Errorf("unexpected response.RelyingPartyID: got %q, want %q", resp.Response.RelyingPartyID, want)
-		}
-		if t.Failed() {
-			return
-		}
-
-		// Verify that we have a session with the stored session data.
-		uu, _ := url.Parse(server.URL)
-
-		var sessionID string
-		for _, cookie := range client.client.Jar.Cookies(uu) {
-			if cookie.Name == "session" {
-				sessionID = cookie.Value
-				break
-			}
-		}
-		if sessionID == "" {
-			t.Fatalf("no session cookie found")
-		}
-
-		var sess *db.Session
-		idp.db.Read(func(d *data) {
-			sess = d.Sessions[sessionID]
-		})
-		if sess == nil {
-			t.Fatalf("no session found in database")
-		}
-		if !sess.IsEphemeral {
-			t.Errorf("session is not ephemeral")
-		}
-		if sess.WebAuthnSession == nil {
-			t.Errorf("no WebAuthn session found in session")
+		if want := rp.ID; resp.Options.Response.RelyingPartyID != want {
+			t.Fatalf("unexpected response.RelyingPartyID: got %q, want %q", resp.Options.Response.RelyingPartyID, want)
 		}
 
 		// Now, complete the login using our virtual credential.
 		authenticator.AddCredential(cred)
 
-		assertionOptions, err := virtualwebauthn.ParseAssertionOptions(string(respBytes))
+		// Slightly annoying, but we need to re-serialize the Options
+		// struct so our virtualwebauthn library can parse it.
+		optionsBytes, _ := json.Marshal(resp.Options)
+
+		assertionOptions, err := virtualwebauthn.ParseAssertionOptions(string(optionsBytes))
 		if err != nil {
 			t.Fatalf("failed to parse assertion options: %v", err)
 		}
@@ -175,6 +151,7 @@ func TestWebauthnLogin(t *testing.T) {
 			"username":          []string{"andrew@du.nham.ca"},
 			"via":               []string{"webauthn"},
 			"webauthn_response": []string{assertionResponse},
+			"webauthn_session":  []string{resp.Session},
 		}
 		loginResp := client.PostForm(server.URL+"/login", body, withCSRFToken(csrfToken))
 
@@ -187,6 +164,8 @@ func TestWebauthnLogin(t *testing.T) {
 		}
 
 		// Verify that our client has a valid session.
+		uu, _ := url.Parse(server.URL)
+
 		var sessionCookie *http.Cookie
 		for _, cookie := range client.client.Jar.Cookies(uu) {
 			if cookie.Name == "session" {

--- a/internal/templates/login.html.tmpl
+++ b/internal/templates/login.html.tmpl
@@ -17,6 +17,7 @@
               <input type="password" name="password" placeholder="Enter your password">
 
               <input type="hidden" name="webauthn_response" id="webauthn-response" value="">
+              <input type="hidden" name="webauthn_session" id="webauthn-session" value="">
               {{ .csrfField }}
             </fieldset>
           </form>
@@ -44,9 +45,12 @@
       // Get the entered username (email address).
       const username = document.querySelector('input[name="username"]').value;
 
-      window.homeauth.doLogin(username).then((cred) => {
+      window.homeauth.doLogin(username).then((response) => {
+        const { credential, session } = response;
+
         // Update the form field with the credential response and submit it.
-        document.getElementById('webauthn-response').value = JSON.stringify(cred);
+        document.getElementById('webauthn-response').value = JSON.stringify(credential);
+        document.getElementById('webauthn-session').value = session;
 
         // We need a 'via' field to tell the server that this is a WebAuthn
         // login. Create an element named that and append it to the form before submitting.

--- a/static/js/webauthn.js
+++ b/static/js/webauthn.js
@@ -207,14 +207,20 @@
         return r.json();
       })
       .then((data) => {
+        const { options, session } = data;
+
         // Un-base64 the challenge and user ID
-        data = translateSessionData(data);
+        const toptions = translateSessionData(options);
 
         // Call the navigator.credentials.get method to begin logging in.
-        console.log("calling navigator.credentials.get with:", data);
-        return navigator.credentials.get(data);
+        console.log("calling navigator.credentials.get with:", toptions);
+        return Promise.all([
+          navigator.credentials.get(toptions),
+          session,
+        ]);
       })
-      .then((cred) => {
+      .then((promises) => {
+        const [ cred, session ] = promises;
         console.log("got credential:", cred);
 
         // 'response' is of type AuthenticatorAssertionResponse, since per MDN:
@@ -238,7 +244,10 @@
 
         // Resolve the promise with the credential, so that the caller can
         // transmit it to the server in an appropriate method.
-        return newCred;
+        return {
+          credential: newCred,
+          session: session,
+        };
       })
       .catch((err) => {
         console.error("error:", err);


### PR DESCRIPTION
As @zofrex helpfully pointed out, we don't actually need to use a session or cookie here, since we can just encrypt/authenticate the WebAuthn session data and have the client pass it back to us using regular HTTP requests. This simplifies a few things, and moves further towards not requiring sessions for unauthenticated users.

(extracted from #20)

Updates #4