### PR TITLE
.github, integration: install Caddy in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
 
+      - name: Install integration test dependencies
+        run: |
+          ./integration/misc/install-caddy.sh
+
       - name: Run all unit tests
         run: go test ./...
 

--- a/integration/helpers_test.go
+++ b/integration/helpers_test.go
@@ -98,6 +98,7 @@ func startHomeauth(tb testing.TB, bin string, opts startOptions) (context.Contex
 		"--verbose",
 		"--listen", "fd://3",
 		"--db", dbPath,
+		"--cookies-secure=false",
 	}
 	if opts.ServerURL != "" {
 		args = append(args, "--server-url", opts.ServerURL)
@@ -188,6 +189,9 @@ func (t *tester) loginPassword(user, password string) {
 		t.tb.Fatalf("making POST request to /login: %v", err)
 	}
 	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.tb.Fatalf("got status %d, want 200", resp.StatusCode)
+	}
 
 	// Ensure that the user is authenticated by fetching the /account page
 	resp = t.MustGet("/account")
@@ -196,7 +200,7 @@ func (t *tester) loginPassword(user, password string) {
 	}
 	body, _ = io.ReadAll(resp.Body)
 	if !bytes.Contains(body, []byte("Account Information")) {
-		t.tb.Fatalf("expected 'Account Information' in body")
+		t.tb.Fatalf("expected 'Account Information' in body; got:\n%s", body)
 	}
 }
 

--- a/integration/misc/install-caddy.sh
+++ b/integration/misc/install-caddy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+main() {
+    APIDATA="$(curl -fsSL https://api.github.com/repos/caddyserver/caddy/releases/latest)"
+    DOWNLOAD_URL="$(echo "$APIDATA" | jq -r '.assets[] | select(.name | test("linux_amd64.tar.gz$")) | .browser_download_url')"
+
+    # Fetch the latest version
+    curl -Lo /tmp/caddy.tar.gz -fsSL "$DOWNLOAD_URL"
+
+    # Extract the binary
+    tar -C /tmp -xzf /tmp/caddy.tar.gz caddy
+
+    # Install the binary to the /usr/local/bin directory; requires root.
+    sudo install -m 755 /tmp/caddy /usr/local/bin/caddy
+}
+
+main "$@"


### PR DESCRIPTION
This allows us to run integration tests in CI.

Updates #7