### PR TITLE
cmd/homeauth: bind password sessions to password

### DIFF
--- a/cmd/homeauth/homeauth.go
+++ b/cmd/homeauth/homeauth.go
@@ -698,6 +698,7 @@ func (s *idpServer) loginUserSession(w http.ResponseWriter, r *http.Request, use
 	// TODO: double-check if this allows session fixation
 	err := s.sessions.Update(r.Context(), func(sd *sessionData) error {
 		sd.UserUUID = user.UUID
+		sd.PasswordBinding = getPasswordBinding(user)
 		return nil
 	})
 	if err != nil {

--- a/cmd/homeauth/testclient_test.go
+++ b/cmd/homeauth/testclient_test.go
@@ -85,6 +85,19 @@ func (c *testClient) SetCookies(u string, cookies ...*http.Cookie) {
 	c.client.Jar.SetCookies(uu, cookies)
 }
 
+// ClearAllCookies clears all cookies from this client's cookie jar.
+func (c *testClient) ClearAllCookies() {
+	// We can't really clear all cookies from the jar, so we just create a
+	// new one.
+	jar, err := cookiejar.New(&cookiejar.Options{
+		PublicSuffixList: publicsuffix.List,
+	})
+	if err != nil {
+		c.tb.Fatalf("failed to create cookie jar: %v", err)
+	}
+	c.client.Jar = jar
+}
+
 // MakeRequest is the underlying method for making requests to the test server.
 //
 // It will create a request with the provided method and path, will set the


### PR DESCRIPTION
If a session is created by a user, and that user later changes their password, the session should no longer be valid. This is true even if we don't offer a password-change endpoint (i.e. password hashes live in the config file).

Updates #29