### PR TITLE
cmd/homeauth: magic login links should use POST

### DIFF
--- a/cmd/homeauth/homeauth.go
+++ b/cmd/homeauth/homeauth.go
@@ -367,6 +367,7 @@ func (s *idpServer) httpHandler() http.Handler {
 		// Login endpoints for magic link login
 		r.Get("/login/check-email", s.serveGetLoginCheckEmail)
 		r.Get("/login/magic", s.serveGetMagicLogin)
+		r.Post("/login/magic", s.servePostMagicLogin)
 
 		// Login endpoints for WebAuthn
 		r.Post("/login/webauthn", s.serveWebauthnBeginLogin)

--- a/internal/templates/login-magic.html.tmpl
+++ b/internal/templates/login-magic.html.tmpl
@@ -1,0 +1,30 @@
+{{ template "_layout.html.tmpl" . }}
+
+{{ define "title" }}Login Page{{ end }}
+
+{{ define "content" }}
+  <div class="container">
+    <h3>Logging you in...</h3>
+
+    <form id="login" action="/login/magic" method="POST">
+      <input type="hidden" name="token" id="token" value="{{.Token}}">
+      {{ .csrfField }}
+      <noscript>
+        <input type="submit" value="Click here to log in...">
+      </noscript>
+    </form>
+  </div>
+
+  <script>
+    // If the self-submitting form doesn't work for some reason, show a submit
+    // button after a bit.
+    setTimeout(function() {
+      var submitButton = document.createElement('input');
+      submitButton.type = 'submit';
+      submitButton.value = 'Click here to log in...';
+      document.getElementById('login').appendChild(submitButton);
+    }, 2000);
+
+    document.getElementById('login').submit();
+  </script>
+{{ end }}


### PR DESCRIPTION
Now, when a user clicks on a magic login link, we render a HTML page that contains a form that immediately submits itself, which makes a POST request to actually complete the login.

This prevents an overzealous email client or security scanner from "clicking" on the URL, making a GET request, and then invalidating the token before a user can use it.

Updates #32