### PR TITLE
cmd/homeauth: add 'remember username' checkbox to login page

### DIFF
--- a/internal/templates/login.html.tmpl
+++ b/internal/templates/login.html.tmpl
@@ -11,7 +11,12 @@
           <form id="login" action="/login?next={{.Next}}" method="POST">
             <fieldset>
               <label for="username">Username</label>
-              <input type="text" name="username" placeholder="Enter your username">
+              <input type="text" name="username" placeholder="Enter your username" value="{{ .Username }}">
+
+              <input type="checkbox" name="remember" id="remember" {{ if .Username }}checked{{ end }}>
+              <label for="remember" class="label-inline">
+                <small>Remember username</small>
+              </label>
               
               <label for="password">Password</label>
               <input type="password" name="password" placeholder="Enter your password">


### PR DESCRIPTION
If checked, this sets a client-side cookie that remembers the username for 30 days. The cookie is removed if the user explicitly logs out, or if another user logs in, though not if a session expires.

Updates #36